### PR TITLE
Refactor speed test automation and add result identifier

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -1,159 +1,198 @@
-from selenium import webdriver
-from selenium.webdriver.common.by import By
-import time
-import pandas as pd
 from datetime import datetime
+from pathlib import Path
+from typing import Tuple
+
 import gspread
-import pygsheets
+import pandas as pd
 from oauth2client.service_account import ServiceAccountCredentials
 from pydrive.auth import GoogleAuth
 from pydrive.drive import GoogleDrive
-import pywhatkit as kit
+from selenium import webdriver
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
 
-def semaforizacion(valor, verde, naranja, rojo):
+SPEEDTEST_URL = 'https://www.speedtest.net/run'
+SCOPE = ['https://spreadsheets.google.com/feeds', 'https://www.googleapis.com/auth/drive']
+GOOGLE_SHEET_KEY = '1j-gxQwT31Eu3Y_8YiN-FEMQROrXSID7aX5AykqiJolM'
+DRIVE_FOLDER_ID = '1VIu4e8gCy0kqroVW_kq4_Xo6kq0dcotu'
+LOCAL_BASE_PATH = Path('C:/Users/PC-04/Desktop/SpeedTest')
+EXCEL_PATH = LOCAL_BASE_PATH / 'SpeedTest.xlsx'
+SCREENSHOT_DIR = LOCAL_BASE_PATH / 'Screenshots'
+CREDENTIALS_PATH = LOCAL_BASE_PATH / 'client_secret.json'
+CHANNEL = 'principal'
+DATA_COLUMNS = [
+    'Fecha',
+    'Canal',
+    'Jornada',
+    'Descargar (Mb/s)',
+    'Cargar (Mb/s)',
+    'Latencia (ms)',
+    'Result ID',
+    'Evidencia',
+    'Observación',
+]
+
+
+def semaforizacion(valor: float, verde: float, naranja: float, rojo: float) -> str:
     if valor > verde:
         return 'Verde'
-    elif valor > naranja:
+    if valor > naranja:
         return 'Naranja'
-    else:
-        return 'Rojo'
+    return 'Rojo'
 
-def observacion(descarga, carga, latencia):
+
+def observacion(descarga: str, carga: str, latencia: str) -> str:
     if descarga == 'Verde' and carga == 'Verde' and latencia == 'Verde':
         return 'Red estable'
-    elif descarga != 'Verde':
+    if descarga != 'Verde':
         return 'Descarga inestable'
-    elif carga != 'Verde':
+    if carga != 'Verde':
         return 'Carga inestable'
-    elif latencia != 'Verde':
+    if latencia != 'Verde':
         return 'Latencia inestable'
-    else:
-        return 'Estado desconocido'
+    return 'Estado desconocido'
 
-driver = webdriver.Chrome()
-driver.maximize_window()
-driver.get('https://www.speedtest.net/run')
-time.sleep(60)
 
-# Obtiene los resultados del test y reemplaza el punto por una coma
-download_speed = float(driver.find_element(By.CSS_SELECTOR, '.download-speed').text.replace(',', '.'))
-upload_speed = float(driver.find_element(By.CSS_SELECTOR, '.upload-speed').text.replace(',', '.'))
-ping_speed = float(driver.find_element(By.CSS_SELECTOR, '.ping-speed').text.replace(',', '.').replace("'", ""))
+def wait_for_value(driver: webdriver.Chrome, css_selector: str, timeout: int = 120) -> str:
+    element = WebDriverWait(driver, timeout).until(
+        EC.visibility_of_element_located((By.CSS_SELECTOR, css_selector))
+    )
+    return element.text.strip()
 
-# Espera a que aparezca el modal
-time.sleep(10)
 
-# Intenta encontrar el botón de cierre y hacer clic en él
-try:
-    close_button = driver.find_element(By.CSS_SELECTOR, '.close-btn.pure-button.pure-button-primary')
-    if close_button:
-        print("Botón de cierre encontrado.")
+def get_speedtest_results(driver: webdriver.Chrome) -> Tuple[float, float, float, str]:
+    download_text = wait_for_value(driver, '.download-speed')
+    upload_text = wait_for_value(driver, '.upload-speed')
+    ping_text = wait_for_value(driver, '.ping-speed')
+
+    download_speed = float(download_text.replace(',', '.'))
+    upload_speed = float(upload_text.replace(',', '.'))
+    ping_speed = float(ping_text.replace(',', '.').replace("'", ''))
+
+    try:
+        result_id_text = wait_for_value(driver, '.result-data', timeout=60)
+    except TimeoutException:
+        result_id_text = ''
+
+    return download_speed, upload_speed, ping_speed, result_id_text
+
+
+def close_modal_if_present(driver: webdriver.Chrome) -> None:
+    try:
+        close_button = WebDriverWait(driver, 10).until(
+            EC.element_to_be_clickable((By.CSS_SELECTOR, '.close-btn.pure-button.pure-button-primary'))
+        )
+    except TimeoutException:
+        return
+
+    try:
         close_button.click()
-        print("Se hizo clic en el botón de cierre.")
-    else:
-        print("Botón de cierre no encontrado.")
-    # Espera a que el modal se cierre
-    time.sleep(2)
-except Exception as e:
-    print(f"No se pudo cerrar el modal: {e}")
+        WebDriverWait(driver, 5).until(EC.invisibility_of_element(close_button))
+    except Exception as exc:  # noqa: BLE001
+        print(f'No se pudo cerrar el modal: {exc}')
 
 
+def determine_jornada() -> Tuple[str, int]:
+    current_hour = datetime.now().hour
+    if current_hour < 12:
+        return 'Mañana', 1
+    if current_hour < 14:
+        return 'Mañana', 2
+    return 'Tarde', 1
 
-# Semaforización
-download_status = semaforizacion(download_speed, 80, 50, 0)
-upload_status = semaforizacion(upload_speed, 80, 60, 0)
-ping_status = semaforizacion(ping_speed, 0, 30, 60)
 
-# Observación
-observacion_status = observacion(download_status, upload_status, ping_status)
+def load_existing_data(path: Path) -> pd.DataFrame:
+    if path.exists():
+        return pd.read_excel(path)
+    return pd.DataFrame(columns=DATA_COLUMNS)
 
-# Determina la jornada en función de la hora actual
-current_hour = datetime.now().hour
-if current_hour < 12:
-    jornada = 'Mañana'
-    num_tests = 1
-elif current_hour < 14:
-    jornada = 'Mañana'
-    num_tests = 2
-else:
-    jornada = 'Tarde'
-    num_tests = 1
 
-df_existing = pd.read_excel('C:/Users/PC-04/Desktop/SpeedTest/SpeedTest.xlsx')
+def update_local_excel(df_existing: pd.DataFrame, df_new: pd.DataFrame, path: Path) -> None:
+    df_updated = pd.concat([df_existing, df_new], ignore_index=True)
+    df_updated.to_excel(path, index=False)
 
-# Crea un DataFrame con tus datos
-data = {
-    'Fecha': [datetime.now().strftime('%d/%m/%Y').replace("'", "")],
-    'Canal': ['principal'],
-    'Jornada': [jornada.lower()],
-    'Descargar (Mb/s)': [download_speed],
-    'Cargar (Mb/s)': [upload_speed],
-    'Latencia (ms)': [ping_speed],
-    'Evidencia': [f'Evidencia {datetime.now().strftime("%d/%m/%Y")}'],
-    'Observación': [observacion_status]
-}
-df_new = pd.DataFrame(data)
 
-# Añade los nuevos datos al DataFrame existente
-df_updated = pd.concat([df_existing, df_new], ignore_index=True)
+def upload_screenshot_to_drive(drive_client: GoogleDrive, screenshot_path: Path, jornada: str, num_tests: int) -> str:
+    file_title = f'{jornada}-{datetime.now().strftime("%d%m%Y")}.{num_tests}.png'
+    file_drive = drive_client.CreateFile({'title': file_title, 'parents': [{'id': DRIVE_FOLDER_ID}]})
+    file_drive.SetContentFile(str(screenshot_path))
+    file_drive.Upload()
+    file_drive.InsertPermission({'type': 'anyone', 'value': 'anyone', 'role': 'reader'})
+    return file_drive['alternateLink']
 
-# Escribe el DataFrame actualizado al archivo Excel
-df_updated.to_excel('C:/Users/PC-04/Desktop/SpeedTest/SpeedTest.xlsx', index=False)
 
-screenshot_path = f'C:/Users/PC-04/Desktop/SpeedTest/Screenshots/{jornada}-{datetime.now().strftime("%d%m%Y")}.{num_tests}.png'
-driver.save_screenshot(screenshot_path)
+def append_row_to_sheet(sheet, row_data, evidence_link: str) -> None:
+    existing_rows = len(sheet.get_all_values())
+    target_row = existing_rows + 1
+    sheet.append_row(row_data)
+    formula = '=HIPERVINCULO("{}"; "{}")'.format(
+        evidence_link,
+        f'Evidencia {datetime.now().strftime("%d/%m/%Y")}',
+    )
+    sheet.update_cell(target_row, 8, formula)
 
-scope = ['https://spreadsheets.google.com/feeds', 'https://www.googleapis.com/auth/drive']
-creds = ServiceAccountCredentials.from_json_keyfile_name('C:/Users/PC-04/Desktop/SpeedTest/client_secret.json', scope)
-gauth = GoogleAuth()
-gauth.credentials = creds
-client_drive = GoogleDrive(gauth)
-client_sheets = gspread.authorize(creds)
-sheet = client_sheets.open_by_key('1j-gxQwT31Eu3Y_8YiN-FEMQROrXSID7aX5AykqiJolM').sheet1 # Abre el archivo de Google Sheets y selecciona la primera hoja
 
-# Sube la captura de pantalla a una carpeta específica en Google Drive y le da el nombre correcto
-file_drive = client_drive.CreateFile({'title': f'{jornada}-{datetime.now().strftime("%d%m%Y")}.{num_tests}.png', 'parents': [{'id': '1VIu4e8gCy0kqroVW_kq4_Xo6kq0dcotu'}]})
-file_drive.SetContentFile(screenshot_path)
-file_drive.Upload()
+def main() -> None:
+    driver = webdriver.Chrome()
+    driver.maximize_window()
+    driver.get(SPEEDTEST_URL)
 
-file_drive.InsertPermission({
-    'type': 'anyone',
-    'value': 'anyone',
-    'role': 'reader'
-})
+    try:
+        download_speed, upload_speed, ping_speed, result_id = get_speedtest_results(driver)
+        close_modal_if_present(driver)
 
-share_link = file_drive['alternateLink']
+        download_status = semaforizacion(download_speed, 80, 50, 0)
+        upload_status = semaforizacion(upload_speed, 80, 60, 0)
+        ping_status = semaforizacion(ping_speed, 0, 30, 60)
+        observacion_status = observacion(download_status, upload_status, ping_status)
 
-# Añade una nueva fila con los datos al final de la hoja de cálculo y actualiza la celda con el hipervínculo 
-row = [datetime.now().strftime('%d/%m/%Y'), 'principal', jornada.lower(), download_speed, upload_speed, ping_speed, f'Evidencia {datetime.now().strftime("%d/%m/%Y")}', observacion_status]
-index = len(sheet.get_all_values()) + 1
-sheet.append_row(row)
-formula = '=HIPERVINCULO("{}"; "{}")'.format(share_link, f'Evidencia {datetime.now().strftime("%d/%m/%Y")}')
-sheet.update_cell(index, 7, formula)
+        jornada, num_tests = determine_jornada()
 
-driver.quit()
+        df_existing = load_existing_data(EXCEL_PATH)
+        data = {
+            'Fecha': [datetime.now().strftime('%d/%m/%Y').replace("'", '')],
+            'Canal': [CHANNEL],
+            'Jornada': [jornada.lower()],
+            'Descargar (Mb/s)': [download_speed],
+            'Cargar (Mb/s)': [upload_speed],
+            'Latencia (ms)': [ping_speed],
+            'Result ID': [result_id],
+            'Evidencia': [f'Evidencia {datetime.now().strftime("%d/%m/%Y")}'],
+            'Observación': [observacion_status],
+        }
+        df_new = pd.DataFrame(data, columns=DATA_COLUMNS)
+        update_local_excel(df_existing, df_new, EXCEL_PATH)
 
-# Prepara el mensaje de WhatsApp
-emoji_download = '🟢' if download_status == 'Verde' else '🟠' if download_status == 'Naranja' else '🔴'
-emoji_upload = '🟢' if upload_status == 'Verde' else '🟠' if upload_status == 'Naranja' else '🔴'
-emoji_ping = '🟢' if ping_status == 'Verde' else '🟠' if ping_status == 'Naranja' else '🔴'
-emoji_observacion = '✅' if observacion_status == 'Red estable' else '⚠'
+        SCREENSHOT_DIR.mkdir(parents=True, exist_ok=True)
+        screenshot_path = SCREENSHOT_DIR / f'{jornada}-{datetime.now().strftime("%d%m%Y")}.{num_tests}.png'
+        driver.save_screenshot(str(screenshot_path))
 
-whatsapp_message = f"\n*🌐 SpeedTest STMC {datetime.now().strftime('%d/%m/%Y')}*\n"\
-                   f"\n*● Estado:* {observacion_status} {emoji_observacion}\n"\
-                   f"\n*● Canal:* principal\n"\
-                   f"\n*● Jornada:* {jornada.lower()}\n"\
-                   f"\n*● Descarga (Mb/s):* {download_speed} {emoji_download}\n"\
-                   f"\n*● Subida (Mb/s):* {upload_speed} {emoji_upload}\n"\
-                   f"\n*● Latencia (ms):* {ping_speed} {emoji_ping}\n"\
-                   f"\n*● Evidencia:* {share_link}\n"\
-                   f"\n\nPara más detalles, por favor visita el siguiente enlace: https://docs.google.com/spreadsheets/d/1j-gxQwT31Eu3Y_8YiN-FEMQROrXSID7aX5AykqiJolM/edit#gid=0"\
-                   f"\n\n\n_Mensaje de tipo notificación enviado por sistema automatizado._"\
-                   
-# Obtiene la hora actual y añade un minuto
-now = datetime.now()
-hours = now.hour
-minutes = now.minute + 1
+        creds = ServiceAccountCredentials.from_json_keyfile_name(str(CREDENTIALS_PATH), SCOPE)
+        gauth = GoogleAuth()
+        gauth.credentials = creds
+        drive_client = GoogleDrive(gauth)
+        sheets_client = gspread.authorize(creds)
+        sheet = sheets_client.open_by_key(GOOGLE_SHEET_KEY).sheet1
 
-# Envia el mensaje
-kit.sendwhatmsg_instantly("+573208647379", whatsapp_message, wait_time=10)
+        share_link = upload_screenshot_to_drive(drive_client, screenshot_path, jornada, num_tests)
+
+        row = [
+            datetime.now().strftime('%d/%m/%Y'),
+            CHANNEL,
+            jornada.lower(),
+            download_speed,
+            upload_speed,
+            ping_speed,
+            result_id,
+            f'Evidencia {datetime.now().strftime("%d/%m/%Y")}',
+            observacion_status,
+        ]
+        append_row_to_sheet(sheet, row, share_link)
+    finally:
+        driver.quit()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- refactor the speed test script into reusable functions and constants while removing the WhatsApp notification logic
- load and update local/remote records with an additional Result ID column sourced from the web result panel
- improve reliability by waiting for elements with WebDriverWait and ensuring screenshot uploads retain public sharing permissions

## Testing
- python -m compileall speedtest.py

------
https://chatgpt.com/codex/tasks/task_e_68d1a829a7008321a890cb1a8d159536